### PR TITLE
Fix tablefield init for new records

### DIFF
--- a/sitemenu/static/admin/sitemenu/js/tablefield.js
+++ b/sitemenu/static/admin/sitemenu/js/tablefield.js
@@ -37,7 +37,11 @@
 
         textarea.hide();
 
-        var data = $.parseJSON(textarea.val());
+        var data = null;
+        if (textarea.val().length) {
+            data = $.parseJSON(textarea.val());
+        }
+
         if(data === null){
             data = {
                 width: 1,


### PR DESCRIPTION
If textarea is empty parseJSON throw error "Unexpected end of input"