### PR TITLE
Fix  deprication warning

### DIFF
--- a/sitemenu/plugins/feedback_form/urls.py
+++ b/sitemenu/plugins/feedback_form/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from views import save_feedback_form
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^send/$', save_feedback_form, name='save_feedback_form'),
-)
+]


### PR DESCRIPTION
Fixing RemovedInDjango110Warning: django.conf.urls.patterns() – Update your urlpatterns to be a list of django.conf.urls.url() instances instead